### PR TITLE
Use a 'leaky bucket' rate limiting algorithm using aiolimiter.AsyncLimiter.

### DIFF
--- a/octopus_api.py
+++ b/octopus_api.py
@@ -1,25 +1,23 @@
 import asyncio
 import time
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 import aiohttp
+from aiolimiter import AsyncLimiter
 from tqdm import tqdm
 
 
 class TentacleSession(aiohttp.ClientSession):
-    """ TentacleSession is a wrapper around the aiohttp.ClientSession, where it introduces the retry and rate functionality
-     missing in the default aiohttp.ClientSession.
+    """ TentacleSession is a wrapper around the aiohttp.ClientSession, where it introduces retry functionality.
 
         Args:
-            sleep (float): The time the client will sleep after each request. \n
-      	    retries (int): The number of retries for a successful request. \n
-     	    retry_sleep (float): The time service sleeps between nonsuccessful request calls. Defaults to 1.0.
+            retries (int): The number of retries for an unsuccessful request.
+            retry_sleep (float): The time service sleeps between nonsuccessful request calls. Defaults to 1.0.
+            kwargs: Additional args passed through to the underlying aiohttp.ClientSession.
 
         Returns:
             TentacleSession(aiohttp.ClientSession)
     """
-    retries: int
-    retry_sleep: float = 1.0
 
     def __init__(self, retries=3, retry_sleep=1.0, **kwargs):
         self.retries = retries
@@ -58,62 +56,56 @@ class TentacleSession(aiohttp.ClientSession):
 class OctopusApi:
     """ Initiates the Octopus client.
         Args:
-            rate (Optional[float]): The rate limits of the endpoint; default to no limit. \n
- 	        resolution (Optional[str]): The time resolution of the rate (sec, minute), defaults to None.
-	        connections (Optional[int]): Maximum connections on the given endpoint, defaults to 5.
+            limiter (Optional[AsyncLimiter]): The session task rate limiter.
+            connections (Optional[int]): Maximum connections on the given endpoint, defaults to 5.
+            retries (int): The number of retries for an unsuccessful request, defaults to 3.
 
         Returns:
             OctopusApi
     """
-    rate_sec: float = None
-    connections: int
-    retries: int
 
-    def __init__(self, rate: int = None, resolution: str = None, connections: int = 5,
-                 retries: int = 3):
+    class __NullAsyncLimiter:
+        async def __aenter__(self): pass
+        async def __aexit__(self, exc_type, exc, tb): pass
 
-        if rate or resolution:
-            if resolution.lower() not in ["minute", "sec"]:
-                raise ValueError("Incorrect value of resolution, expecting minute or sec!")
-            if not rate:
-                raise ValueError("Can not set resolution of rate without rate")
-            self.rate_sec = rate / (60 if resolution.lower() == "minute" else 1)
+    __null_limiter = __NullAsyncLimiter()
 
-        self.connections = connections
-        self.retries = retries
+    def __init__(self, limiter: Optional[AsyncLimiter] = None, connections: int = 5, retries: int = 3):
+        self.limiter: Optional[AsyncLimiter] = limiter
+        self.connections: int = connections
+        self.retries: int = retries
 
     def get_coroutine(self, requests_list: List[Dict[str, Any]], func: callable):
 
-        async def __tentacles__(rate: float, retries: int, connections: int, requests_list: List[Dict[str, Any]],
-                                func: callable) -> List[Any]:
+        async def __tentacles__(limiter: Optional[AsyncLimiter], retries: int, connections: int,
+                                requests_list: List[Dict[str, Any]], func: callable) -> List[Any]:
 
             responses_order: Dict = {}
             progress_bar = tqdm(total=len(requests_list))
-            sleep = 1 / rate if rate else 0
+            retry_sleep = limiter.time_period / limiter.max_rate if limiter else 0
 
-            async def func_mod(session: TentacleSession, request: Dict, itr: int):
-                resp = await func(session, request)
-                responses_order[itr] = resp
-                progress_bar.update()
+            async def func_mod(session: TentacleSession, limiter: Optional[AsyncLimiter], request: Dict, itr: int):
+                async with limiter if limiter else OctopusApi.__null_limiter:
+                    resp = await func(session, request)
+                    responses_order[itr] = resp
+                    progress_bar.update()
 
             conn = aiohttp.TCPConnector(limit_per_host=connections)
             async with TentacleSession(retries=retries,
-                                       retry_sleep=sleep * self.connections * 2.0 if rate else 1.0,
+                                       retry_sleep=retry_sleep * self.connections * 2.0 if retry_sleep else 1,
                                        connector=conn) as session:
 
                 tasks = set()
-                itr = 0
-                for request in requests_list:
+                for itr, request in enumerate(requests_list):
                     if len(tasks) >= self.connections:
+                        # handle connections overflow by waiting for at least one running task to complete...
                         _done, tasks = await asyncio.wait(
                             tasks, return_when=asyncio.FIRST_COMPLETED)
-                    tasks.add(asyncio.create_task(func_mod(session, request, itr)))
-                    await asyncio.sleep(sleep)
-                    itr += 1
+                    tasks.add(asyncio.create_task(func_mod(session, limiter, request, itr)))
                 await asyncio.wait(tasks)
                 return [value for (key, value) in sorted(responses_order.items())]
 
-        return __tentacles__(self.rate_sec, self.retries, self.connections, requests_list, func)
+        return __tentacles__(self.limiter, self.retries, self.connections, requests_list, func)
 
     def execute(self, requests_list: List[Dict[str, Any]], func: callable) -> List[Any]:
         """ Execute the requests given the functions instruction.
@@ -122,12 +114,12 @@ class OctopusApi:
             Given a list of requests, the result is ordered list of what the user-defined function returns.
 
             Args:
-                requests_list (List[Dict[str, Any]): The list of requests in a dictionary format, e.g.
-                [{"url": "http://example.com", "params": {...}, "body": {...}}..]
-                func (callable): The user-defined function to execute, this function takes in the following arguments.
-                    Args:
-                        session (TentacleSession): The Octopus wrapper around the aiohttp.ClientSession.
-                        request (Dict): The request within the requests_list above.
+                requests_list (List[Dict[str, Any]): The list of requests in a dictionary format,
+                  e.g. `[{"url": "http://example.com", "params": {...}, "body": {...}}..]`
+                func (callable): The user-defined function to execute. This function takes in the following arguments:
+
+                  - session (TentacleSession): The Octopus wrapper around the aiohttp.ClientSession.
+                  - request (Dict): The request within the requests_list above.
 
             Returns:
                 List(func->return)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ python = "^3.7"
 asyncio = "^3.4.3"
 aiohttp = "^3.8.1"
 tqdm = "^4.62.3"
+aiolimiter = "^1.1.0"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
The current implementation introduces a delay between each request irrespective of whether or not the rate limit has been reached.

A more efficient algorithm is the 'leaky bucket' implementation of aiolimiter.AsyncLimiter. This supports ["bursting'](https://aiolimiter.readthedocs.io/en/latest/#bursting) where the rate limiter has no effect until the limit has been reached. Only then are subsequent requests delayed.

Note that the existing functionality - a regular delay between all requests - can still be achieved by applying a rate limiter with a count of 1, e.g. ```client = OctopusApi(limiter=AsyncLimiter(1, 1/requests_per_second))```


A further advantage of this code is that the same `AsyncLimiter` instance can be shared across multiple OctopusApi sessions, ensuring consistent application of rate limiting if a series of calls are made to various URLs on the same API service, using multiple OctopusApi sessions.
